### PR TITLE
0.0.9: The "Bug Fixes 1" Update

### DIFF
--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -25,6 +25,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pdoc
+          python -m pip install pandas
+          python -m pip install tqdm
+          python -m pip install bs4
+          python -m pip install lxml
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: run Python Script
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG: cfbd_json_py
 
+## 0.0.10: The "Metrics" Update
+
+## 0.0.9: The "Bug Fixes 1" Update
+- Attempted another fix for the `generate_docs.yml` GitHub Workflow to allow it to call `pdoc` properly within GitHub Actions.
+- Removed the PyArrow package as a required package for this python package.
+- Updated the package version to `0.0.9`.
+
 ## 0.0.8: The "Games" Update
 
 - Implemented `cfbd_json_py.games.get_cfbd_player_advanced_game_stats()`, a function that allows a user to get advanced player game stats for actual CFB games in a specific timeframe, from the CFBD API.

--- a/cfbd_json_py/drives.py
+++ b/cfbd_json_py/drives.py
@@ -1,5 +1,5 @@
 # Creation Date: 08/30/2023 01:13 EDT
-# Last Updated Date: 10/07/2023 10:16 AM EDT
+# Last Updated Date: 10/11/2023 8:58 PM EDT
 # Author: Joseph Armstrong (armstrongjoseph08@gmail.com)
 # File Name: drives.py
 # Purpose: Houses functions pertaining to CFB drive data within the CFBD API.

--- a/cfbd_json_py/games.py
+++ b/cfbd_json_py/games.py
@@ -1,5 +1,5 @@
 # Creation Date: 08/30/2023 01:13 EDT
-# Last Updated Date: 10/06/2023 07:53 PM EDT
+# Last Updated Date: 10/19/2023 01:36 PM EDT
 # Author: Joseph Armstrong (armstrongjoseph08@gmail.com)
 # File Name: games.py
 # Purpose: Houses functions pertaining to CFB game data within the CFBD API.

--- a/cfbd_json_py/metrics.py
+++ b/cfbd_json_py/metrics.py
@@ -1,5 +1,5 @@
 # Creation Date: 08/30/2023 01:13 EDT
-# Last Updated Date: 10/06/2023 07:53 PM EDT
+# Last Updated Date: 10/19/2023 01:48 PM EDT
 # Author: Joseph Armstrong (armstrongjoseph08@gmail.com)
 # File Name: metrics.py
 # Purpose: Houses functions pertaining to various CFB stats within the CFBD API.

--- a/cfbd_json_py/venues.py
+++ b/cfbd_json_py/venues.py
@@ -1,5 +1,5 @@
 # Creation Date: 08/30/2023 01:13 EDT
-# Last Updated Date: 10/06/2023 07:54 PM EDT
+# Last Updated Date: 10/15/2023 06:57 PM EDT
 # Author: Joseph Armstrong (armstrongjoseph08@gmail.com)
 # File Name: venues.py
 # Purpose: Houses functions pertaining to CFB team venues/stadium data within the CFBD API.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools","wheel","pyarrow","pandas","tqdm","requests","lxml"]
+requires = ["setuptools","wheel","pandas","tqdm","requests","lxml"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
- Attempted another fix for the `generate_docs.yml` GitHub Workflow to allow it to call `pdoc` properly within GitHub Actions.
- Removed the PyArrow package as a required package for this python package.
- Updated the package version to `0.0.9`.