### PR TITLE
Fourth Attempt at fixing `generate_docs.yml`

### DIFF
--- a/cfbd_json_py/games.py
+++ b/cfbd_json_py/games.py
@@ -2862,8 +2862,9 @@ def get_cfbd_player_game_stats(
                                 f"Unhandled stat: \t{stat['name']}")
 
                 else:
-                    raise IndexError(f"Unhandled stat category: \t{
-                                     s_category['name']}")
+                    raise IndexError(
+                        f"Unhandled stat category: \t{s_category['name']}"
+                    )
 
     for key, value in tqdm(rebuilt_json.items()):
         # print(key)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cfbd_json_py"
-version = "0.0.8"
+version = "0.0.9"
 readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "MIT"}


### PR DESCRIPTION
Fixed an issue found in line 2865 in `cfbd_json_py.games.get_cfbd_player_game_stats()` that would result in a syntax error, due to an issue identified when using the `autopep8` formatter in Visual Studio Code.