### PR TITLE
0.2.1 The "College Football is BACK! (2024)" Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG: cfbd_json_py
 
+## 0.2.1 The "College Football is BACK! (2024)" Update
+- Fixed a bug in `cfbd_json_py.drives.get_cfbd_drives_info()` where the `ncaa_division` parameter would become malformed, the API call wouldn't filter by `ncaa_division`, but the API call would still be accepted.
+- Updated the package to comply with changes made in version `4.6.0` of the CFBD V1 API. These changes in this API version removed the `game_id` parameter from `cfbd_json_py.betting.get_cfbd_betting_lines()` and from `cfbd_json_py.games.get_cfbd_weather_info()`.
+- Updated the package version to `0.2.1`.
+
 ## 0.2.0 The "Patreon" Update
 - Re-implemented the process of storing a user's API key. If you have used `cfbd_json_py.utls.set_cfbd_api_token()` in the past, you do not need to do anything to migrate your API key to this new process.
 - The following functions require a user to subscribe to the [CFBD Patreon](https://www.patreon.com/collegefootballdata):

--- a/cfbd_api_version.json
+++ b/cfbd_api_version.json
@@ -1,3 +1,3 @@
 {
-  "current_version": "4.5.2"
+  "current_version": "4.6.0"
 }

--- a/cfbd_json_py/betting.py
+++ b/cfbd_json_py/betting.py
@@ -5,7 +5,7 @@
 # Purpose: Houses functions pertaining to betting data within the CFBD API.
 ###############################################################################
 
-import warnings
+# import warnings
 
 import pandas as pd
 import requests
@@ -18,7 +18,7 @@ def get_cfbd_betting_lines(
     season: int = None,
     api_key: str = None,
     api_key_dir: str = None,
-    game_id: int = None,
+    # game_id: int = None,
     week: int = None,
     season_type: str = "regular",  # "regular" or "postseason"
     team: str = None,
@@ -61,7 +61,7 @@ def get_cfbd_betting_lines(
         and will try to find a CFBD API key file in that directory.
 
     `game_id` (int, optional):
-        Optional argument.
+        DEPRECATED FROM V1.
         If `game_id` is set to a game ID,
         `get_cfb_betting_lines()` will try to get
         all betting information for that game ID.
@@ -402,12 +402,12 @@ def get_cfbd_betting_lines(
 
     del year, home, away
 
-    if game_id is not None and season is not None:
-        warnings.warn(
-            "If you are getting betting information for a single game, "
-            + "only set `game_id` to the game ID, " +
-            "and leave `season` as `NULL`."
-        )
+    # if game_id is not None and season is not None:
+    #     warnings.warn(
+    #         "If you are getting betting information for a single game, "
+    #         + "only set `game_id` to the game ID, " +
+    #         "and leave `season` as `NULL`."
+    #     )
 
     if season_type == "regular" or season_type == "postseason":
         url += f"seasonType={season_type}"
@@ -416,7 +416,12 @@ def get_cfbd_betting_lines(
             '`season_type` must be set to either "regular" or "postseason".'
         )
 
-    if (game_id is None) and (season is None) and (week is not None):
+    # if (game_id is None) and (season is None) and (week is not None):
+    #     raise ValueError(
+    #         "When setting a value for `week`, `season` cannot be null."
+    #     )
+
+    if (season is None) and (week is not None):
         raise ValueError(
             "When setting a value for `week`, `season` cannot be null."
         )
@@ -441,8 +446,8 @@ def get_cfbd_betting_lines(
     # URL builder
     ##########################################################################
 
-    if game_id is not None:
-        url += f"&gameId={game_id}"
+    # if game_id is not None:
+    #     url += f"&gameId={game_id}"
 
     if season is not None:
         url += f"&year={season}"

--- a/cfbd_json_py/drives.py
+++ b/cfbd_json_py/drives.py
@@ -620,7 +620,7 @@ def get_cfbd_drives_info(
         url += f"&defenseConference={defensive_conference}"
 
     if ncaa_division is not None:
-        url += f"&classification={ncaa_division.lower}"
+        url += f"&classification={ncaa_division.lower()}"
 
     headers = {
         "Authorization": f"{real_api_key}",

--- a/cfbd_json_py/games.py
+++ b/cfbd_json_py/games.py
@@ -4524,7 +4524,7 @@ def get_cfbd_live_scoreboard(
 
 
 def get_cfbd_weather_info(
-    game_id: int = None,
+    # game_id: int = None,
     season: int = None,
     # `game_id` and/or `season` must be not null for this function to work.
     week: int = None,
@@ -4549,7 +4549,7 @@ def get_cfbd_weather_info(
     ----------
 
     `game_id` (int, mandatory):
-        Mandatory requirement.
+        DEPRECATED FROM V1.
         Specifies the game you want weather data from.
         This or `season` must be set to a valid non-null value.
 
@@ -4899,14 +4899,21 @@ def get_cfbd_weather_info(
     else:
         real_api_key = "Bearer " + real_api_key
 
-    if (game_id is None) and (season is None):
+    # if (game_id is None) and (season is None):
+    #     raise ValueError(
+    #         "`game_id` and/or `season` must be set to " +
+    #         "valid, non-null values."
+    #     )
+    # elif (game_id is not None) and (season is not None):
+    #     url += f"?gameId={game_id}&year={season}"
+    # elif game_id is not None:
+    #     url += f"?gameId={game_id}"
+    # elif season is not None:
+    #     url += f"?year={season}"
+    if season is None:
         raise ValueError(
-            "`game_id` and/or `season` must be set to valid, non-null values."
+            "`season` must be set to a valid, non-null value."
         )
-    elif (game_id is not None) and (season is not None):
-        url += f"?gameId={game_id}&year={season}"
-    elif game_id is not None:
-        url += f"?gameId={game_id}"
     elif season is not None:
         url += f"?year={season}"
 

--- a/cfbd_json_py/utls.py
+++ b/cfbd_json_py/utls.py
@@ -364,5 +364,8 @@ def _set_cfbd_api_token(api_key: str, api_key_dir: str = None):
 #     key = "hello world"
 #     set_cfbd_api_token("text")
 #     print(key)
+
+# if __name__ == "__main__":
+
 #     return_key = get_cfbd_api_token()
 #     print(return_key)


### PR DESCRIPTION
- Fixed a bug in `cfbd_json_py.drives.get_cfbd_drives_info()` where the `ncaa_division` parameter would become malformed, the API call wouldn't filter by `ncaa_division`, but the API call would still be accepted.
- Updated the package to comply with changes made in version `4.6.0` of the CFBD V1 API. These changes in this API version removed the `game_id` parameter from `cfbd_json_py.betting.get_cfbd_betting_lines()` and from `cfbd_json_py.games.get_cfbd_weather_info()`.
- Updated the package version to `0.2.1`.