### PR TITLE
0.2.5 The "Remove lxml" Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG: cfbd_json_py
 
+# 0.2.5 The "Remove lxml" Update
+- Removed `lxml` from the list of required packages to fix a build issue observed in version `0.2.4`.
+- Updated the package version to `0.2.5`.
 
 ## 0.2.4 The "Speedy" Update.
 - Refactored `cfbd_json_py.games.get_cfbd_player_game_stats()`, `cfbd_json_py.plays.get_cfbd_pbp_play_types()`, and `cfbd_json_py.players.get_cfbd_player_season_stats()` to use a significantly faster process to parse player stats.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools","wheel","pandas","tqdm","requests","lxml"]
+requires = ["setuptools","wheel","pandas","tqdm","requests"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -37,8 +37,7 @@ dependencies = [
     "pandas>=2.2.2",
     "tqdm",
     "requests",
-    "keyring",
-    "lxml"
+    "keyring"
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ pandas>=2.2.2
 tqdm
 requests
 keyring>=25.3.0
-lxml


### PR DESCRIPTION
- Removed `lxml` from the list of required packages to fix a build issue observed in version `0.2.4`.
- Updated the package version to `0.2.5`.